### PR TITLE
Allow colon at start of dict literal

### DIFF
--- a/src/Typst/Parse.hs
+++ b/src/Typst/Parse.hs
@@ -987,10 +987,9 @@ pArrayExpr =
 -- dict-expr ::= '(' (':' | ':'? (pair (',' pair)* ','?)) ')'
 -- pair ::= (ident | str) ':' expr
 pDictExpr :: P Expr
-pDictExpr = try $ inParens (try pNonemptyDict <|> pEmptyDict)
+pDictExpr = try $ inParens (sym ":" *> (pNonemptyDict <|> pure (Dict mempty)) <|> pNonemptyDict)
   where
-    pEmptyDict = Dict mempty <$ sym ":"
-    pNonemptyDict = Dict <$> (optional (sym ":") *> sepEndBy1 (pSpread <|> pPair) (sym ","))
+    pNonemptyDict = Dict <$> sepEndBy1 (pSpread <|> pPair) (sym ",")
     pPair = Reg <$> ((,) <$> pExpr <*> try (sym ":" *> pExpr))
 
 pSpread :: P (Spreadable a)

--- a/src/Typst/Parse.hs
+++ b/src/Typst/Parse.hs
@@ -984,13 +984,13 @@ pArrayExpr =
       )
         <|> (Array [] <$ optional (void $ sym ","))
 
--- dict-expr ::= '(' (':' | (pair (',' pair)* ','?)) ')'
+-- dict-expr ::= '(' (':' | ':'? (pair (',' pair)* ','?)) ')'
 -- pair ::= (ident | str) ':' expr
 pDictExpr :: P Expr
-pDictExpr = try $ inParens (pEmptyDict <|> pNonemptyDict)
+pDictExpr = try $ inParens (try pNonemptyDict <|> pEmptyDict)
   where
     pEmptyDict = Dict mempty <$ sym ":"
-    pNonemptyDict = Dict <$> sepEndBy1 (pSpread <|> pPair) (sym ",")
+    pNonemptyDict = Dict <$> (optional (sym ":") *> sepEndBy1 (pSpread <|> pPair) (sym ","))
     pPair = Reg <$> ((,) <$> pExpr <*> try (sym ":" *> pExpr))
 
 pSpread :: P (Spreadable a)

--- a/test/out/compiler/spread-09.out
+++ b/test/out/compiler/spread-09.out
@@ -1,3 +1,127 @@
-"test/typ/compiler/spread-09.typ" (line 14, column 9):
-unexpected ":"
-expecting "//", "/*", "none", "auto", "true", "false", "0b", "0x", "0o", digit, ".", "\"", "let", "set", "show", "if", "while", "for", "import", "include", "break", "continue", "return", "(", "<", "```", "`", "$", "{" or "["
+--- parse tree ---
+[ Code
+    "test/typ/compiler/spread-09.typ"
+    ( line 1 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "test")))
+       (FuncExpr
+          [ NormalParam (Identifier "x") , NormalParam (Identifier "y") ]
+          (Block
+             (CodeBlock
+                [ If
+                    [ ( Equals (Ident (Identifier "x")) (Ident (Identifier "y"))
+                      , Block (Content [ Text "\9989" ])
+                      )
+                    , ( Literal (Boolean True)
+                      , Block
+                          (Content
+                             [ Text "\10060"
+                             , Text "("
+                             , Code
+                                 "test/typ/compiler/spread-09.typ"
+                                 ( line 1 , column 47 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "x")) ])
+                             , Space
+                             , Text "/"
+                             , Text "="
+                             , Space
+                             , Code
+                                 "test/typ/compiler/spread-09.typ"
+                                 ( line 1 , column 59 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "y")) ])
+                             , Text ")"
+                             ])
+                      )
+                    ]
+                ]))))
+, SoftBreak
+, Comment
+, Code
+    "test/typ/compiler/spread-09.typ"
+    ( line 3 , column 2 )
+    (Block
+       (CodeBlock
+          [ Let
+              (BasicBind (Just (Identifier "l")))
+              (Array
+                 [ Reg (Literal (Int 1))
+                 , Reg (Literal (Int 2))
+                 , Reg (Literal (Int 3))
+                 ])
+          , Let
+              (BasicBind (Just (Identifier "r")))
+              (Array
+                 [ Reg (Literal (Int 5))
+                 , Reg (Literal (Int 6))
+                 , Reg (Literal (Int 7))
+                 ])
+          , FuncCall
+              (Ident (Identifier "test"))
+              [ NormalArg
+                  (Array
+                     [ Spr (Ident (Identifier "l"))
+                     , Reg (Literal (Int 4))
+                     , Spr (Ident (Identifier "r"))
+                     ])
+              , NormalArg
+                  (FuncCall
+                     (Ident (Identifier "range"))
+                     [ NormalArg (Literal (Int 1)) , NormalArg (Literal (Int 8)) ])
+              ]
+          , FuncCall
+              (Ident (Identifier "test"))
+              [ NormalArg (Dict [ Spr (Literal None) ]) , NormalArg (Array []) ]
+          ]))
+, ParBreak
+, Code
+    "test/typ/compiler/spread-09.typ"
+    ( line 10 , column 2 )
+    (Block
+       (CodeBlock
+          [ Let
+              (BasicBind (Just (Identifier "x")))
+              (Dict [ Reg ( Ident (Identifier "a") , Literal (Int 1) ) ])
+          , Let
+              (BasicBind (Just (Identifier "y")))
+              (Dict [ Reg ( Ident (Identifier "b") , Literal (Int 2) ) ])
+          , Let
+              (BasicBind (Just (Identifier "z")))
+              (Dict [ Reg ( Ident (Identifier "a") , Literal (Int 3) ) ])
+          , FuncCall
+              (Ident (Identifier "test"))
+              [ NormalArg
+                  (Dict
+                     [ Spr (Ident (Identifier "x"))
+                     , Spr (Ident (Identifier "y"))
+                     , Spr (Ident (Identifier "z"))
+                     ])
+              , NormalArg
+                  (Dict
+                     [ Reg ( Ident (Identifier "a") , Literal (Int 3) )
+                     , Reg ( Ident (Identifier "b") , Literal (Int 2) )
+                     ])
+              ]
+          , FuncCall
+              (Ident (Identifier "test"))
+              [ NormalArg
+                  (Dict
+                     [ Spr (Dict [ Reg ( Ident (Identifier "a") , Literal (Int 1) ) ])
+                     , Reg ( Ident (Identifier "b") , Literal (Int 2) )
+                     ])
+              , NormalArg
+                  (Dict
+                     [ Reg ( Ident (Identifier "a") , Literal (Int 1) )
+                     , Reg ( Ident (Identifier "b") , Literal (Int 2) )
+                     ])
+              ]
+          ]))
+, ParBreak
+]
+"test/typ/compiler/spread-09.typ" (line 3, column 2):
+unexpected end of input
+expecting end of input
+Could not spread TNone into dictionary

--- a/test/out/regression/issue43.out
+++ b/test/out/regression/issue43.out
@@ -67,11 +67,57 @@
        (BasicBind (Just (Identifier "x")))
        (Block (Content [ RawInline "hello" ])))
 , ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 10 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "a")))
+       (Dict [ Reg ( Ident (Identifier "a") , Literal (Int 1) ) ]))
+, ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 12 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "b")))
+       (Dict [ Reg ( Ident (Identifier "b") , Literal (Int 2) ) ]))
+, ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 14 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "c")))
+       (Dict [ Reg ( Ident (Identifier "c") , Literal (Int 3) ) ]))
+, ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 16 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "d")))
+       (Dict [ Spr (Ident (Identifier "a")) ]))
+, ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 18 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "e")))
+       (Dict [ Spr (Ident (Identifier "b")) ]))
+, ParBreak
+, Code
+    "test/typ/regression/issue43.typ"
+    ( line 20 , column 2 )
+    (Let (BasicBind (Just (Identifier "f"))) (Dict []))
+, ParBreak
 ]
 --- evaluated ---
 document(body: { text(body: [
 ]), 
                  <foo:bar>, 
+                 parbreak(), 
+                 parbreak(), 
+                 parbreak(), 
+                 parbreak(), 
+                 parbreak(), 
+                 parbreak(), 
                  parbreak(), 
                  parbreak(), 
                  parbreak(), 

--- a/test/typ/regression/issue43.typ
+++ b/test/typ/regression/issue43.typ
@@ -5,3 +5,15 @@
 #let w = x => $x$ + x
 
 #let x = `hello`
+
+#let a = (a:1)
+
+#let b = (:b:2)
+
+#let c = ( : c : 3)
+
+#let d = (:..a)
+
+#let e = ( : ..b)
+
+#let f = (:)


### PR DESCRIPTION
Resolves #45 and #43.

Allowing a colon at the start of a dict literal allows the following expressions, which before this was parsed by typst but not by typst-hs:

```typ
#let a = (:a:1)
#let b = ( : b : 2)
#let c = (:..a)
```

Adding `optional (sym ":") *> ...` at `Parse.hs:993` wasn't quite enough due to:
* On input `(:a:1)`, `pEmptyDict` successfully parsed all its content (the symbol `:`)
* Since it consumed input, `<|>` killed the second branch (`pNonemptyDict`)
* `inParens` failed since it looked for the closing bracket, when there were still elements to be parsed, making the parsing fail
* I resolved it by first `try`ing to parse it as a non-empty dict, with `try` allowing it to fallback to an empty dict if it finds an initial `:` and starts parsing, but then fails due to no entries being in the dict
* This may possibly lead to worse error messages (possibly, I am unsure), feel free to change this if you have a better idea

Regression tests were added (to the existing `regression/issue43.typ`)

One other test changed: `spread-09` compiler test. It tested spreading arrays and dicts, and previously it failed on the parser step (since dict spreading wasn't available). Now it fails due to another bug: apparently `#let x = (..none)` is parsed as a dict spreading rather than an array spreading. Since array parsing has priority over dict parsing, the error is due to the array parsing not allowing that expression. (You can try this out in the old parser, before this PR, parsing `#let x = (..none)` fails). We could make a separate case in the dict parser that `:` is not optional if it only contains spread statements, but I think this is unnecessary since if we fix the array parser, this will be a non-issue, and statements like `#let x = (..a, b:2)` is allowed in Typst (without initial `:`). I will create an issue for the array spread parser issue.
