### PR TITLE
WebAssembly backend compatibility

### DIFF
--- a/src/Typst/Module/Standard.hs
+++ b/src/Typst/Module/Standard.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -33,7 +34,9 @@ import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
 import Text.Parsec (getPosition, getState, updateState, runParserT)
 import Text.Read (readMaybe)
+#ifndef __WASM_COMPAT__
 import qualified Text.XML as XML
+#endif
 import qualified Toml
 import Typst.Emoji (typstEmojis)
 import Typst.Module.Calc (calcModule)
@@ -442,13 +445,13 @@ loremWords :: [Text]
 loremWords =
   cycle $
     T.words $
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\
-      \ eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut\
-      \ enim ad minim veniam, quis nostrud exercitation ullamco laboris\
-      \ nisi ut aliquip ex ea commodo consequat.  Duis aute irure dolor in\
-      \ reprehenderit in voluptate velit esse cillum dolore eu fugiat\
-      \ nulla pariatur. Excepteur sint occaecat cupidatat non proident,\
-      \ sunt in culpa qui officia deserunt mollit anim id est laborum."
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do" <>
+      " eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut" <>
+      " enim ad minim veniam, quis nostrud exercitation ullamco laboris" <>
+      " nisi ut aliquip ex ea commodo consequat.  Duis aute irure dolor in" <>
+      " reprehenderit in voluptate velit esse cillum dolore eu fugiat" <>
+      " nulla pariatur. Excepteur sint occaecat cupidatat non proident," <>
+      " sunt in culpa qui officia deserunt mollit anim id est laborum."
 
 toRatio :: MonadFail m => Val -> m Rational
 toRatio (VRatio r) = pure r
@@ -560,10 +563,11 @@ dataLoading =
       makeFunction $ do
         bs <- getFileOrBytes
         case Toml.decode (TE.decodeUtf8 $ BL.toStrict bs) of
-          Toml.Failure e -> fail (unlines ("toml errors:" : e))
+          Toml.Failure e -> fail (unlines ("tom,l errors:" : e))
           Toml.Success _ v -> pure v
-    ),
-    ( "xml",
+    )
+#ifndef __WASM_COMPAT__
+    , ( "xml",
       makeFunction $ do
         bs <- getFileOrBytes
         case XML.parseLBS XML.def bs of
@@ -598,6 +602,7 @@ dataLoading =
                       )
                     ]
     )
+#endif
   ]
 
 applyPureFunction :: Function -> [Val] -> Attempt Val

--- a/typst.cabal
+++ b/typst.cabal
@@ -75,7 +75,7 @@ library
                       cassava,
                       aeson,
                       scientific,
-                      xml-conduit,
+                      -- xml-conduit,
                       yaml,
                       toml-parser ^>= 2.0.0.0,
                       regex-tdfa,
@@ -87,10 +87,18 @@ library
       cpp-options: -D__MACOS__
     if os(windows)
       cpp-options: -D__WINDOWS__
+    if !flag(wasm_compat)
+      build-depends: xml-conduit
+    if flag(wasm_compat)
+      cpp-options: -D__WASM_COMPAT__
     default-language: Haskell2010
 
 Flag executable
   description:       Compile executable to be used in testing and development.
+  default:           False
+
+Flag wasm_compat
+  description:       Exclude the XML support for WASM backend compatibility. 
   default:           False
 
 executable typst-hs


### PR DESCRIPTION
Typst has an interface that supports plugins written in WebAssembly (WASM), while GHC also has a WASM backend. As such, we have the motivation to write Typst plugins using Haskell. For this purpose, it is essential for the `typst-hs` package to be compatible with the WASM backend of GHC. 

Currently the `typst-hs` package is not compatible with the WASM backend due to the dependency chain `typst` - `xml-conduit` - `conduit-extra` - `streaming-commons` - `network`, where `network` is incompatible with WASM (https://gitlab.haskell.org/ghc/ghc/-/issues/23354). Anyways, `typst` only uses an XML parser from `xml-conduit` and doesn't use any networking features, but the parser and the network features seems bundled together and hard to separate. 

I thus created this pull request, which added a cabal flag `wasm_compat` to the `typst-hs` project that, when turned on, removes the dependency on `xml-conduit` at the cost of dropping XML parsing support. This makes it compatible with the WASM backend on my computer with this `wasm_compat` flag turned on. It is not a pretty solution, but should work as a temporary solution for now. 