### PR TITLE
WASM compatibility

### DIFF
--- a/typst.cabal
+++ b/typst.cabal
@@ -75,7 +75,7 @@ library
                       cassava,
                       aeson,
                       scientific,
-                      xml-conduit,
+                      xml,
                       yaml,
                       toml-parser ^>= 2.0.0.0,
                       regex-tdfa,


### PR DESCRIPTION
As suggested in https://github.com/jgm/typst-hs/pull/72 , it is better to migrate to a more lightweight XML library for XML parsing, than to drop this feature completely for WASM compat. I've changed the XML library from `xml-conduit` to `xml`, and the test suite passed. Now `typst` works with the WASM backend. 