### PR TITLE
Improve handling of control flow statements at loop block boundaries

### DIFF
--- a/test/typ/regression/issue58-break-continue.out
+++ b/test/typ/regression/issue58-break-continue.out
@@ -1,0 +1,271 @@
+--- parse tree ---
+[ Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 1 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "test")))
+       (FuncExpr
+          [ NormalParam (Identifier "x") , NormalParam (Identifier "y") ]
+          (Block
+             (CodeBlock
+                [ If
+                    [ ( Equals (Ident (Identifier "x")) (Ident (Identifier "y"))
+                      , Block (Content [ Text "\9989" ])
+                      )
+                    , ( Literal (Boolean True)
+                      , Block
+                          (Content
+                             [ Text "\10060"
+                             , Text "("
+                             , Code
+                                 "typ/regression/issue58-break-continue.typ"
+                                 ( line 1 , column 47 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "x")) ])
+                             , Space
+                             , Text "/"
+                             , Text "="
+                             , Space
+                             , Code
+                                 "typ/regression/issue58-break-continue.typ"
+                                 ( line 1 , column 59 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "y")) ])
+                             , Text ")"
+                             ])
+                      )
+                    ]
+                ]))))
+, SoftBreak
+, Comment
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 3 , column 2 )
+    (LetFunc
+       (Identifier "f")
+       []
+       (Block
+          (CodeBlock
+             [ For
+                 (BasicBind (Just (Identifier "i")))
+                 (FuncCall
+                    (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                 (Block
+                    (CodeBlock
+                       [ For
+                           (BasicBind (Just (Identifier "j")))
+                           (FuncCall
+                              (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Break
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 14 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "f")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 0)) , Reg (Literal (Int 0)) ])
+              , Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 0)) ])
+              , Reg (Negated (Literal (Int 1)))
+              ])
+       ])
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 16 , column 2 )
+    (LetFunc
+       (Identifier "g")
+       []
+       (Block
+          (CodeBlock
+             [ For
+                 (BasicBind (Just (Identifier "i")))
+                 (FuncCall
+                    (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                 (Block
+                    (CodeBlock
+                       [ For
+                           (BasicBind (Just (Identifier "j")))
+                           (FuncCall
+                              (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Continue
+                                 , Array [ Reg (Plus (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       , Array [ Reg (Plus (Literal (Int 100)) (Ident (Identifier "i"))) ]
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 28 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "g")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 0)) , Reg (Literal (Int 0)) ])
+              , Reg (Array [ Reg (Literal (Int 0)) , Reg (Literal (Int 1)) ])
+              , Reg (Literal (Int 100))
+              , Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 0)) ])
+              , Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 1)) ])
+              , Reg (Literal (Int 101))
+              , Reg (Negated (Literal (Int 1)))
+              ])
+       ])
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 30 , column 2 )
+    (LetFunc
+       (Identifier "f")
+       []
+       (Block
+          (CodeBlock
+             [ Let (BasicBind (Just (Identifier "i"))) (Literal (Int 0))
+             , While
+                 (LessThan (Ident (Identifier "i")) (Literal (Int 2)))
+                 (Block
+                    (CodeBlock
+                       [ Assign
+                           (Ident (Identifier "i"))
+                           (Plus (Ident (Identifier "i")) (Literal (Int 1)))
+                       , Let (BasicBind (Just (Identifier "j"))) (Literal (Int 0))
+                       , While
+                           (LessThan (Ident (Identifier "j")) (Literal (Int 2)))
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Assign
+                                     (Ident (Identifier "j"))
+                                     (Plus (Ident (Identifier "j")) (Literal (Int 1)))
+                                 , Break
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       , Array [ Reg (Plus (Literal (Int 100)) (Ident (Identifier "i"))) ]
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 46 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "f")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 0)) ])
+              , Reg (Literal (Int 101))
+              , Reg (Array [ Reg (Literal (Int 2)) , Reg (Literal (Int 0)) ])
+              , Reg (Literal (Int 102))
+              , Reg (Negated (Literal (Int 1)))
+              ])
+       ])
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 48 , column 2 )
+    (LetFunc
+       (Identifier "g")
+       []
+       (Block
+          (CodeBlock
+             [ Let (BasicBind (Just (Identifier "i"))) (Literal (Int 0))
+             , While
+                 (LessThan (Ident (Identifier "i")) (Literal (Int 2)))
+                 (Block
+                    (CodeBlock
+                       [ Assign
+                           (Ident (Identifier "i"))
+                           (Plus (Ident (Identifier "i")) (Literal (Int 1)))
+                       , Let (BasicBind (Just (Identifier "j"))) (Literal (Int 0))
+                       , While
+                           (LessThan (Ident (Identifier "j")) (Literal (Int 2)))
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Assign
+                                     (Ident (Identifier "j"))
+                                     (Plus (Ident (Identifier "j")) (Literal (Int 1)))
+                                 , Continue
+                                 , Array [ Reg (Plus (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       , Array [ Reg (Plus (Literal (Int 100)) (Ident (Identifier "i"))) ]
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-break-continue.typ"
+    ( line 64 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "g")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 0)) ])
+              , Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 1)) ])
+              , Reg (Literal (Int 101))
+              , Reg (Array [ Reg (Literal (Int 2)) , Reg (Literal (Int 0)) ])
+              , Reg (Array [ Reg (Literal (Int 2)) , Reg (Literal (Int 1)) ])
+              , Reg (Literal (Int 102))
+              , Reg (Negated (Literal (Int 1)))
+              ])
+       ])
+, ParBreak
+]
+--- evaluated ---
+document(body: { text(body: [
+]), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak() })

--- a/test/typ/regression/issue58-break-continue.typ
+++ b/test/typ/regression/issue58-break-continue.typ
@@ -1,0 +1,63 @@
+// Test that `break` and `continue` only affect the innermost loop
+#let f() = {
+  for i in range(2) {
+    for j in range(2) {
+      ((i, j), )
+      break
+      (10 * j,)
+    }
+  }
+  (-1,)
+}
+
+#test(f(), ((0, 0), (1, 0), -1))
+
+#let g() = {
+  for i in range(2) {
+    for j in range(2) {
+      ((i, j), )
+      continue
+      (10 + j,)
+    }
+    (100 + i,)
+  }
+  (-1,)
+}
+
+#test(g(), ((0, 0), (0, 1), 100, (1, 0), (1, 1), 101, -1))
+
+#let f() = {
+  let i = 0
+  while i < 2 {
+    i += 1
+    let j = 0
+    while j < 2 {
+      ((i, j), )
+      j += 1
+      break
+      (10 * j,)
+    }
+    (100 + i,)
+  }
+  (-1,)
+}
+
+#test(f(), ((1, 0), 101, (2, 0), 102, -1))
+
+#let g() = {
+  let i = 0
+  while i < 2 {
+    i += 1
+    let j = 0
+    while j < 2 {
+      ((i, j), )
+      j += 1
+      continue
+      (10 + j,)
+    }
+    (100 + i,)
+  }
+  (-1,)
+}
+
+#test(g(), ((1, 0), (1, 1), 101, (2, 0), (2, 1), 102, -1))

--- a/test/typ/regression/issue58-return.out
+++ b/test/typ/regression/issue58-return.out
@@ -1,0 +1,245 @@
+--- parse tree ---
+[ Code
+    "typ/regression/issue58-return.typ"
+    ( line 1 , column 2 )
+    (Let
+       (BasicBind (Just (Identifier "test")))
+       (FuncExpr
+          [ NormalParam (Identifier "x") , NormalParam (Identifier "y") ]
+          (Block
+             (CodeBlock
+                [ If
+                    [ ( Equals (Ident (Identifier "x")) (Ident (Identifier "y"))
+                      , Block (Content [ Text "\9989" ])
+                      )
+                    , ( Literal (Boolean True)
+                      , Block
+                          (Content
+                             [ Text "\10060"
+                             , Text "("
+                             , Code
+                                 "typ/regression/issue58-return.typ"
+                                 ( line 1 , column 47 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "x")) ])
+                             , Space
+                             , Text "/"
+                             , Text "="
+                             , Space
+                             , Code
+                                 "typ/regression/issue58-return.typ"
+                                 ( line 1 , column 59 )
+                                 (FuncCall
+                                    (Ident (Identifier "repr"))
+                                    [ NormalArg (Ident (Identifier "y")) ])
+                             , Text ")"
+                             ])
+                      )
+                    ]
+                ]))))
+, SoftBreak
+, Comment
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 3 , column 2 )
+    (LetFunc
+       (Identifier "h")
+       []
+       (Block
+          (CodeBlock
+             [ For
+                 (BasicBind (Just (Identifier "i")))
+                 (FuncCall
+                    (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                 (Block
+                    (CodeBlock
+                       [ For
+                           (BasicBind (Just (Identifier "j")))
+                           (FuncCall
+                              (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Return Nothing
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 14 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "h")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 0)) , Reg (Literal (Int 0)) ]) ])
+       ])
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 16 , column 2 )
+    (LetFunc
+       (Identifier "h")
+       []
+       (Block
+          (CodeBlock
+             [ Let (BasicBind (Just (Identifier "i"))) (Literal (Int 0))
+             , While
+                 (LessThan (Ident (Identifier "i")) (Literal (Int 2)))
+                 (Block
+                    (CodeBlock
+                       [ Assign
+                           (Ident (Identifier "i"))
+                           (Plus (Ident (Identifier "i")) (Literal (Int 1)))
+                       , Let (BasicBind (Just (Identifier "j"))) (Literal (Int 0))
+                       , While
+                           (LessThan (Ident (Identifier "j")) (Literal (Int 2)))
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Assign
+                                     (Ident (Identifier "j"))
+                                     (Plus (Ident (Identifier "j")) (Literal (Int 1)))
+                                 , Return Nothing
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       , Array [ Reg (Plus (Literal (Int 100)) (Ident (Identifier "i"))) ]
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 32 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "h")) [])
+       , NormalArg
+           (Array
+              [ Reg (Array [ Reg (Literal (Int 1)) , Reg (Literal (Int 0)) ]) ])
+       ])
+, ParBreak
+, Comment
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 35 , column 2 )
+    (LetFunc
+       (Identifier "h")
+       []
+       (Block
+          (CodeBlock
+             [ For
+                 (BasicBind (Just (Identifier "i")))
+                 (FuncCall
+                    (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                 (Block
+                    (CodeBlock
+                       [ For
+                           (BasicBind (Just (Identifier "j")))
+                           (FuncCall
+                              (Ident (Identifier "range")) [ NormalArg (Literal (Int 2)) ])
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Return (Just (Block (Content [ Text "a" ])))
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 46 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "h")) [])
+       , NormalArg (Block (Content [ Text "a" ]))
+       ])
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 48 , column 2 )
+    (LetFunc
+       (Identifier "h")
+       []
+       (Block
+          (CodeBlock
+             [ Let (BasicBind (Just (Identifier "i"))) (Literal (Int 0))
+             , While
+                 (LessThan (Ident (Identifier "i")) (Literal (Int 2)))
+                 (Block
+                    (CodeBlock
+                       [ Assign
+                           (Ident (Identifier "i"))
+                           (Plus (Ident (Identifier "i")) (Literal (Int 1)))
+                       , Let (BasicBind (Just (Identifier "j"))) (Literal (Int 0))
+                       , While
+                           (LessThan (Ident (Identifier "j")) (Literal (Int 2)))
+                           (Block
+                              (CodeBlock
+                                 [ Array
+                                     [ Reg
+                                         (Array
+                                            [ Reg (Ident (Identifier "i"))
+                                            , Reg (Ident (Identifier "j"))
+                                            ])
+                                     ]
+                                 , Assign
+                                     (Ident (Identifier "j"))
+                                     (Plus (Ident (Identifier "j")) (Literal (Int 1)))
+                                 , Return (Just (Block (Content [ Text "a" ])))
+                                 , Array [ Reg (Times (Literal (Int 10)) (Ident (Identifier "j"))) ]
+                                 ]))
+                       , Array [ Reg (Plus (Literal (Int 100)) (Ident (Identifier "i"))) ]
+                       ]))
+             , Array [ Reg (Negated (Literal (Int 1))) ]
+             ])))
+, ParBreak
+, Code
+    "typ/regression/issue58-return.typ"
+    ( line 64 , column 2 )
+    (FuncCall
+       (Ident (Identifier "test"))
+       [ NormalArg (FuncCall (Ident (Identifier "h")) [])
+       , NormalArg (Block (Content [ Text "a" ]))
+       ])
+, ParBreak
+]
+--- evaluated ---
+document(body: { text(body: [
+]), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak(), 
+                 parbreak(), 
+                 text(body: [✅]), 
+                 parbreak() })

--- a/test/typ/regression/issue58-return.typ
+++ b/test/typ/regression/issue58-return.typ
@@ -1,0 +1,63 @@
+// Test that `return` works from inside loops
+#let h() = {
+  for i in range(2) {
+    for j in range(2) {
+      ((i, j), )
+      return
+      (10 * j,)
+    }
+  }
+  (-1,)
+}
+
+#test(h(), ((0, 0),))
+
+#let h() = {
+  let i = 0
+  while i < 2 {
+    i += 1
+    let j = 0
+    while j < 2 {
+      ((i, j), )
+      j += 1
+      return
+      (10 * j,)
+    }
+    (100 + i,)
+  }
+  (-1,)
+}
+
+#test(h(), ((1, 0),))
+
+// Test that `return val` works from inside loops
+#let h() = {
+  for i in range(2) {
+    for j in range(2) {
+      ((i, j), )
+      return [a]
+      (10 * j,)
+    }
+  }
+  (-1,)
+}
+
+#test(h(), [a])
+
+#let h() = {
+  let i = 0
+  while i < 2 {
+    i += 1
+    let j = 0
+    while j < 2 {
+      ((i, j), )
+      j += 1
+      return [a]
+      (10 * j,)
+    }
+    (100 + i,)
+  }
+  (-1,)
+}
+
+#test(h(), [a])


### PR DESCRIPTION
This addresses

- `break` and `continue` now only affect the innermost `for` and `while` loop by resetting `evalFlowDirective` at the loop end.
- `return` now returns even when used inside a loop: it stops the loop the same way `break` does but its state is not reset at the end of the loop so propagates up to the function boundary.