### PR TITLE
Return an error instead of crashing on integer division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for typst-hs
 
+## 0.11.0.2
+
+  * Return an evaluation error instead of crashing on integer division by
+    zero. `5 / 0`, `calc.quo(5, 0)`, and `calc.rem(5, 0)` raised an uncaught
+    `divide by zero` exception; they now fail gracefully like other
+    evaluation errors.
+
 ## 0.11.0.1
 
   * Fix `calc.pow` so it accepts negative exponents (#102).

--- a/src/Typst/Module/Calc.hs
+++ b/src/Typst/Module/Calc.hs
@@ -157,16 +157,21 @@ calcModule =
         makeFunction $ do
           (a :: Integer) <- nthArg 1
           (b :: Integer) <- nthArg 2
-          pure $ VInteger $ a `quot` b
+          if b == 0
+            then fail "division by zero"
+            else pure $ VInteger $ a `quot` b
       ),
       ( "rem",
         makeFunction $ do
           (a :: Integer, f :: Double) <- properFraction <$> nthArg 1
           (b :: Integer) <- nthArg 2
-          pure $
-            if f == 0
-              then VInteger $ rem a b
-              else VFloat $ fromIntegral (rem a b) + f
+          if b == 0
+            then fail "division by zero"
+            else
+              pure $
+                if f == 0
+                  then VInteger $ rem a b
+                  else VFloat $ fromIntegral (rem a b) + f
       ),
       ( "round",
         makeFunction $ do

--- a/src/Typst/Types.hs
+++ b/src/Typst/Types.hs
@@ -523,9 +523,11 @@ instance Multipliable Val where
   maybeTimes v1 v2 = fail $ "could not multiply " <> show v1 <> " and " <> show v2
 
   maybeDividedBy (VInteger i1) (VInteger i2) =
-    if i1 `mod` i2 == 0
-      then pure $ VInteger (i1 `div` i2)
-      else pure $ VFloat (fromIntegral i1 / fromIntegral i2)
+    if i2 == 0
+      then fail "division by zero"
+      else if i1 `mod` i2 == 0
+        then pure $ VInteger (i1 `div` i2)
+        else pure $ VFloat (fromIntegral i1 / fromIntegral i2)
   maybeDividedBy (VFloat x1) (VFloat x2) = maybeTimes (VFloat x1) (VFloat (1 / x2))
   maybeDividedBy (VInteger i1) (VFloat f2) = pure $ VFloat (fromIntegral i1 / f2)
   maybeDividedBy (VFloat f1) (VInteger i2) = pure $ VFloat (f1 / fromIntegral i2)

--- a/test/typ/regression/pr-103-calc-quo-zero.out
+++ b/test/typ/regression/pr-103-calc-quo-zero.out
@@ -1,0 +1,14 @@
+--- parse tree ---
+[ Comment
+, SoftBreak
+, Code
+    "typ/regression/pr-103-calc-quo-zero.typ"
+    ( line 2 , column 2 )
+    (FuncCall
+       (FieldAccess
+          (Ident (Identifier "quo")) (Ident (Identifier "calc")))
+       [ NormalArg (Literal (Int 5)) , NormalArg (Literal (Int 0)) ])
+, ParBreak
+]
+"typ/regression/pr-103-calc-quo-zero.typ" (line 2, column 2):
+Module does not have a method "quo" or division by zero

--- a/test/typ/regression/pr-103-calc-quo-zero.typ
+++ b/test/typ/regression/pr-103-calc-quo-zero.typ
@@ -1,0 +1,2 @@
+// calc.quo with a zero divisor must error, not crash.
+#calc.quo(5, 0)

--- a/test/typ/regression/pr-103-calc-rem-zero.out
+++ b/test/typ/regression/pr-103-calc-rem-zero.out
@@ -1,0 +1,14 @@
+--- parse tree ---
+[ Comment
+, SoftBreak
+, Code
+    "typ/regression/pr-103-calc-rem-zero.typ"
+    ( line 2 , column 2 )
+    (FuncCall
+       (FieldAccess
+          (Ident (Identifier "rem")) (Ident (Identifier "calc")))
+       [ NormalArg (Literal (Int 5)) , NormalArg (Literal (Int 0)) ])
+, ParBreak
+]
+"typ/regression/pr-103-calc-rem-zero.typ" (line 2, column 2):
+Module does not have a method "rem" or division by zero

--- a/test/typ/regression/pr-103-calc-rem-zero.typ
+++ b/test/typ/regression/pr-103-calc-rem-zero.typ
@@ -1,0 +1,2 @@
+// calc.rem with a zero divisor must error, not crash.
+#calc.rem(5, 0)

--- a/test/typ/regression/pr-103-division-by-zero.out
+++ b/test/typ/regression/pr-103-division-by-zero.out
@@ -1,0 +1,13 @@
+--- parse tree ---
+[ Comment
+, SoftBreak
+, Comment
+, SoftBreak
+, Code
+    "typ/regression/pr-103-division-by-zero.typ"
+    ( line 3 , column 2 )
+    (Divided (Literal (Int 5)) (Literal (Int 0)))
+, ParBreak
+]
+"typ/regression/pr-103-division-by-zero.typ" (line 3, column 2):
+Can't / VInteger 5 and VInteger 0

--- a/test/typ/regression/pr-103-division-by-zero.typ
+++ b/test/typ/regression/pr-103-division-by-zero.typ
@@ -1,0 +1,3 @@
+// Integer division by zero must yield an evaluation error, not crash (uncaught
+// Haskell exception) the evaluator.
+#(5 / 0)


### PR DESCRIPTION
## What

Integer division by zero crashes the evaluator with an uncaught Haskell exception instead of producing an evaluation error. Three code paths call `mod`/`div`/`quot`/`rem` on an untrusted divisor without guarding zero:

- the `/` operator — `maybeDividedBy (VInteger i1) (VInteger i2)` in `Typst.Types` does `i1 \`mod\` i2`
- `calc.quo` — `a \`quot\` b` in `Typst.Module.Calc`
- `calc.rem` — `rem a b` in `Typst.Module.Calc`

So a document containing `#(5 / 0)`, `#calc.quo(5, 0)`, or `#calc.rem(5, 0)` aborts with `divide by zero` rather than returning a `Left`. Any tool that evaluates untrusted typst (e.g. Pandoc's Typst reader) is affected.

## Fix

Guard the zero divisor in all three places and `fail` instead, matching how other evaluation errors are reported. Float division is unchanged (IEEE `/` already yields infinity, as typst expects).

## Verification

Reproduced against `main` with a small driver calling `evaluateTypst`:

```
== 5 / 0 ==         -> CRASHED (uncaught exception): divide by zero
== calc.quo 5 0 ==  -> CRASHED (uncaught exception): divide by zero
== calc.rem 5 0 ==  -> CRASHED (uncaught exception): divide by zero
```

With the fix, all three return a clean evaluation error and `6 / 2` still evaluates to `3`.

Added golden tests (`division-by-zero`, `calc-quo-zero`, `calc-rem-zero`). Full test suite passes (`All 1067 tests passed`).

I bumped the changelog to 0.11.0.2 — happy to change the version or wording to whatever you prefer. The error message for the `/` operator currently renders as `Can't / VInteger 5 and VInteger 0`; I can make it say "division by zero" explicitly if you'd rather.
