### PR TITLE
Return default instead of crashing on negative arguments.at index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for typst-hs
 
+## 0.11.0.2
+
+  * Return the default instead of crashing when `arguments.at` is given a
+    negative index, which previously raised a `Prelude.!!: negative index`
+    exception.
+
 ## 0.11.0.1
 
   * Fix `calc.pow` so it accepts negative exponents (#102).

--- a/src/Typst/Methods.hs
+++ b/src/Typst/Methods.hs
@@ -687,7 +687,7 @@ getMethod updateVal val fld = do
               VInteger{} -> do
                 i <- fromVal x
                 case positional args of
-                  xs | i < length xs -> pure $ xs !! i
+                  xs | i >= 0, i < length xs -> pure $ xs !! i
                      | otherwise -> pure defval
               VString t ->
                 case OM.lookup (Identifier t) (named args) of

--- a/test/typ/regression/pr-105.out
+++ b/test/typ/regression/pr-105.out
@@ -1,0 +1,37 @@
+--- parse tree ---
+[ Comment
+, SoftBreak
+, Comment
+, SoftBreak
+, Code
+    "typ/regression/pr-105.typ"
+    ( line 3 , column 2 )
+    (LetFunc
+       (Identifier "f")
+       [ SinkParam (Just (Identifier "a")) ]
+       (FuncCall
+          (FieldAccess (Ident (Identifier "at")) (Ident (Identifier "a")))
+          [ NormalArg (Negated (Literal (Int 1)))
+          , KeyValArg (Identifier "default") (Literal (String "none"))
+          ]))
+, SoftBreak
+, Code
+    "typ/regression/pr-105.typ"
+    ( line 4 , column 2 )
+    (FuncCall
+       (Ident (Identifier "f"))
+       [ NormalArg (Literal (Int 1))
+       , NormalArg (Literal (Int 2))
+       , NormalArg (Literal (Int 3))
+       ])
+, ParBreak
+]
+--- evaluated ---
+document(body: { text(body: [
+]), 
+                 text(body: [
+]), 
+                 text(body: [
+]), 
+                 text(body: [none]), 
+                 parbreak() })

--- a/test/typ/regression/pr-105.typ
+++ b/test/typ/regression/pr-105.typ
@@ -1,0 +1,4 @@
+// arguments.at with a negative index must return the default (or error), not
+// crash with a Prelude.!!: negative index exception.
+#let f(..a) = a.at(-1, default: "none")
+#f(1, 2, 3)


### PR DESCRIPTION
## What

`arguments.at` crashes with `Prelude.!!: negative index` when given a negative index.

The index is only checked against the upper bound before the list access:

```haskell
case positional args of
  xs | i < length xs -> pure $ xs !! i
     | otherwise -> pure defval
```

A negative `i` satisfies `i < length xs`, so it falls through to `xs !! i`, which raises an uncaught exception:

```
#let f(..a) = a.at(-1)
#f(1, 2, 3)
-- Prelude.!!: negative index  (crashes the evaluator)
```

Any tool evaluating untrusted typst (e.g. Pandoc's Typst reader) is affected.

## Fix

Also require `i >= 0`, returning the default otherwise — exactly what the method already does for an out-of-range positive index. (The sibling `array.at` is already safe because it uses `V.!?`.)

## Verification

Reproduced against `main`: `a.at(-1)` crashes with `Prelude.!!: negative index`. With the fix it returns the default (`a.at(-1, default: "none")` → `none`), and `a.at(0)` still works.

Added a golden test (`arguments-at-negative`). Full suite passes.

Note: third sibling of the "crash on untrusted input in the evaluator" class alongside #103 (integer division by zero) and #104 (out-of-bounds `array.slice`), kept separate since it's an independent fix.
